### PR TITLE
apply changes from Coreforge's rpi-6.6.y-gpu branch and resolve conflicts

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -1665,6 +1665,14 @@ config ARM64_TAGGED_ADDR_ABI
 	  to system calls as pointer arguments. For details, see
 	  Documentation/arch/arm64/tagged-address-abi.rst.
 
+config ARM64_ALIGNMENT_FIXUPS
+	bool "Fix up misaligned loads and stores from userspace for 64bit code"
+	default n
+	help
+	  Userspace may incorrectly assume that certain memory does not need
+	  any special alignment considerations, which may result in Bus Errors.
+	  Enable to handle these faults in the kernel.
+
 menuconfig COMPAT
 	bool "Kernel support for 32-bit EL0"
 	depends on ARM64_4K_PAGES || EXPERT

--- a/arch/arm64/include/asm/exception.h
+++ b/arch/arm64/include/asm/exception.h
@@ -68,6 +68,7 @@ void do_sp_pc_abort(unsigned long addr, unsigned long esr, struct pt_regs *regs)
 void bad_el0_sync(struct pt_regs *regs, int reason, unsigned long esr);
 void do_el0_cp15(unsigned long esr, struct pt_regs *regs);
 int do_compat_alignment_fixup(unsigned long addr, struct pt_regs *regs);
+int do_alignment_fixup(unsigned long addr, struct pt_regs *regs);
 void do_el0_svc(struct pt_regs *regs);
 void do_el0_svc_compat(struct pt_regs *regs);
 void do_el0_fpac(struct pt_regs *regs, unsigned long esr);

--- a/arch/arm64/kernel/Makefile
+++ b/arch/arm64/kernel/Makefile
@@ -40,6 +40,7 @@ obj-$(CONFIG_COMPAT)			+= sys32.o signal32.o			\
 					   sys_compat.o
 obj-$(CONFIG_COMPAT)			+= sigreturn32.o
 obj-$(CONFIG_COMPAT_ALIGNMENT_FIXUPS)	+= compat_alignment.o
+obj-$(CONFIG_ARM64_ALIGNMENT_FIXUPS)	+= compat_alignment_64.o
 obj-$(CONFIG_KUSER_HELPERS)		+= kuser32.o
 obj-$(CONFIG_FUNCTION_TRACER)		+= ftrace.o entry-ftrace.o
 obj-$(CONFIG_MODULES)			+= module.o module-plts.o

--- a/arch/arm64/kernel/compat_alignment_64.c
+++ b/arch/arm64/kernel/compat_alignment_64.c
@@ -1,0 +1,946 @@
+
+#include <linux/kernel.h>
+#include <linux/ktime.h>
+#include <linux/timekeeping.h>
+#include <linux/uaccess.h>
+#include <linux/slab.h>
+
+#include <asm/fpsimd.h>
+#include <asm/neon.h>
+#include <asm/simd.h>
+#include <asm/ptrace.h>
+#include <asm/traps.h>
+
+#include <generated/asm/sysreg-defs.h>
+
+/*
+ *Happens with The Long Dark (also with steam)
+ *
+ *[ 6012.660803] Faulting instruction: 0x3d800020
+[ 6012.660813] Load/Store: op0 0x3 op1 0x1 op2 0x3 op3 0x0 op4 0x0
+ *
+ *[  555.449651] Load/Store: op0 0x3 op1 0x1 op2 0x1 op3 0x1 op4 0x0
+[  555.449654] Faulting instruction: 0x3c810021
+ *
+ *
+ *[  555.449663] Load/Store: op0 0x3 op1 0x1 op2 0x1 op3 0x2 op4 0x0
+[  555.449666] Faulting instruction: 0x3c820020
+ *
+ *[  555.449674] Load/Store: op0 0x3 op1 0x1 op2 0x1 op3 0x3 op4 0x0
+[  555.449677] Faulting instruction: 0x3c830021
+
+stur	q1, [x1, #16]
+potentially also ldur	q0, [x1, #32] and ldur	q1, [x1, #48]
+ *
+ *
+ *
+ */
+
+
+struct fixupDescription {
+	void *addr;
+
+	// datax_simd has to be located directly after datax in memory
+	// u64 data1;
+	// u64 data1_simd;
+	// u64 data2;
+	// u64 data2_simd;
+
+	int reg1;
+	int reg2;
+
+	int Rs;		// used for atomics (which don't get handled atomically)
+
+	int simd;	// whether or not this is a vector instruction
+	int load;	// 1 is it's a load, 0 if it's a store
+	int pair;	// 1 if it's a l/s pair instruction
+	int width;	// width of the access in bits
+	int extendSign;
+	int extend_width;
+
+	// profiling
+	u64 starttime;
+	u64 decodedtime;
+	u64 endtime;
+};
+
+static __always_inline int alignment_get_arm64(struct pt_regs *regs, __le64 __user *ip, u32 *inst)
+{
+	__le32 instr = 0;
+	int fault;
+
+	fault = get_user(instr, ip);
+	if (fault)
+		return fault;
+
+	*inst = __le32_to_cpu(instr);
+	return 0;
+}
+
+__always_inline int64_t extend_sign(int64_t in, int bits)
+{
+	bits--;
+	if (in & (1 << bits)) {
+		// extend sign
+		return (0xffffffffffffffff << bits) | in;
+	}
+	return in;
+}
+
+// saves the contents of the simd register reg to dst
+__always_inline void read_simd_reg(int reg, u64 dst[2])
+{
+	struct user_fpsimd_state st = {0};
+	//fpsimd_save_state(&st);
+
+	if (!may_use_simd())
+		printk("may_use_simd returned false!\n");
+
+	kernel_neon_begin();
+	if (current->thread.sve_state)
+		printk("SVE state is not NULL!\n");
+
+	dst[0] = *((u64 *)(&current->thread.uw.fpsimd_state.vregs[reg]));
+	dst[1] = *(((u64 *)(&current->thread.uw.fpsimd_state.vregs[reg])) + 1);
+
+	kernel_neon_end();
+}
+
+
+__always_inline void write_simd_reg(int reg, u64 src[2])
+{
+	if (!may_use_simd())
+		printk("may_use_simd returned false!\n");
+
+	kernel_neon_begin();
+	if (current->thread.sve_state)
+		printk("SVE state is not NULL!\n");
+
+	*((u64 *)(&current->thread.uw.fpsimd_state.vregs[reg])) = src[0];
+	*(((u64 *)(&current->thread.uw.fpsimd_state.vregs[reg])) + 1) = src[1];
+
+	kernel_neon_end();
+}
+
+// these try to use larger access widths than single bytes. Slower for small loads/stores, but it might speed larger ones up
+
+__always_inline int put_data2(int size, uint8_t *data, void *addr)
+{
+	int r = 0;
+
+	while (size) {
+		if (size >= 4 && (((u64)addr % 4) == 0)) {
+			if ((r=put_user( (*(((uint32_t *)(data)))), (uint32_t __user *)addr)))
+				return r;
+
+			addr += 4;
+			data += 4;
+			size -= 4;
+			continue;
+		}
+		if (size >= 2 && (((u64)addr % 2) == 0)) {
+			if ((r=put_user( (*(((uint16_t *)(data)))), (uint16_t __user *)addr)))
+				return r;
+
+			addr += 2;
+			data += 2;
+			size -= 2;
+			continue;
+		}
+		// I guess the if is redundant here
+		if (size >= 1) {
+			if ((r=put_user( (*(((uint8_t *)(data)))), (uint8_t __user *)addr)))
+				return r;
+
+			addr += 1;
+			data += 1;
+			size -= 1;
+			continue;
+		}
+
+	}
+
+	return r;
+}
+
+__always_inline int get_data2(int size, uint8_t *data, void *addr)
+{
+	int r = 0;
+	uint32_t val32;
+	uint16_t val16;
+	uint8_t val8;
+	while (size) {
+		if (size >= 4 && (((u64)addr % 4) == 0)) {
+			if ((r=get_user( val32, (uint32_t __user *)addr)))
+				return r;
+
+			*((uint32_t *)data) = val32;
+			addr += 4;
+			data += 4;
+			size -= 4;
+			continue;
+		}
+		if (size >= 2 && (((u64)addr % 2) == 0)) {
+			if ((r=get_user( val16, (uint16_t __user *)addr)))
+				return r;
+
+			*((uint16_t *)data) = val16;
+			addr += 2;
+			data += 2;
+			size -= 2;
+			continue;
+		}
+		// I guess the if is redundant here
+		if (size >= 1) {
+			if ((r=get_user( val8, (uint8_t __user *)addr)))
+				return r;
+
+			*((uint8_t *)data) = val8;
+			addr += 1;
+			data += 1;
+			size -= 1;
+			continue;
+		}
+
+	}
+
+	return r;
+}
+
+
+// these should avoid some branching, but still use single byte accesses
+__always_inline int put_data(int size, uint8_t *data, void *addr)
+{
+	int r = 0;
+	int addrIt = 0;
+
+	// with the fixed size loops, the compiler should be able to unroll them
+	// this should mean a lot less branching
+	switch(size) {
+	case 16:
+		for (int i = 0; i < 8; i++) {
+			if ((r=put_user( (*(((uint8_t *)(data)) + addrIt) & 0xff), (uint8_t __user *)addr)))
+				return r;
+
+			addrIt++;
+			addr++;
+		}
+		//__attribute__((fallthrough));
+	case 8:
+		for (int i = 0; i < 4; i++) {
+			if ((r=put_user( (*(data + addrIt) & 0xff), (uint8_t __user *)addr)))
+				return r;
+
+			addrIt++;
+			addr++;
+		}
+		//__attribute__((fallthrough));
+	case 4:
+		for (int i = 0; i < 2; i++) {
+			if ((r=put_user( (*(data + addrIt) & 0xff), (uint8_t __user *)addr)))
+				return r;
+
+			addrIt++;
+			addr++;
+		}
+		//__attribute__ ((fallthrough));
+	case 2:
+		if ((r=put_user( (*(data + addrIt) & 0xff), (uint8_t __user *)addr)))
+			return r;
+
+		addrIt++;
+		addr++;
+		//__attribute__ ((fallthrough));
+	case 1:
+		if ((r=put_user( (*(data + addrIt) & 0xff), (uint8_t __user *)addr)))
+			return r;
+
+		addrIt++;
+		addr++;
+		break;
+	default:
+		printk("unsupported size %d\n", size);
+	}
+
+	return r;
+}
+
+__always_inline int get_data(int size, uint8_t *data, void *addr)
+{
+	int r = 0;
+	int addrIt = 0;
+
+	// with the fixed size loops, the compiler should be able to unroll them
+	// this should mean a lot less branching
+	uint8_t val;
+	switch(size) {
+	case 16:
+		for (int i = 0; i < 8; i++) {
+			if ((r=get_user( val, (uint8_t __user *)addr)))
+				return r;
+
+			*(data + addrIt) = val;
+			addrIt++;
+			addr++;
+		}
+		// fall through
+	case 8:
+		for (int i = 0; i < 4; i++) {
+			if ((r=get_user( val, (uint8_t __user *)addr)))
+				return r;
+
+			*(data + addrIt) = val;
+			addrIt++;
+			addr++;
+		}
+		// fall through
+	case 4:
+		for (int i = 0; i < 2; i++) {
+			if ((r=get_user( val, (uint8_t __user *)addr)))
+				return r;
+
+			*(data + addrIt) = val;
+			addrIt++;
+			addr++;
+		}
+		// fall through
+	case 2:
+		if ((r=get_user( val, (uint8_t __user *)addr)))
+			return r;
+
+		*(data + addrIt) = val;
+		addrIt++;
+		addr++;
+		// fall through
+	case 1:
+		if ((r=get_user( val, (uint8_t __user *)addr)))
+			return r;
+
+		*(data + addrIt) = val;
+		addrIt++;
+		addr++;
+		break;
+	default:
+		printk("unsupported size %d\n", size);
+	}
+
+	return r;
+}
+
+int memset_io_user(uint64_t size, uint8_t c, void *addr)
+{
+	int r = 0;
+	uint64_t pattern = c;
+	pattern |= pattern << 8;
+	pattern |= pattern << 16;
+	pattern |= pattern << 32;
+	uint64_t cnt = 0;
+	while (cnt < size) {
+		if ((uint64_t)(addr + cnt) % 8) {
+			if ((r = put_user(c, (uint8_t __user *) addr)))
+				return r;
+
+			cnt++;
+		} else if (size - cnt >= 8) {
+			if ((r = put_user(pattern, (uint64_t __user *) addr)))
+				return r;
+
+			cnt += 8;
+		} else {
+			if ((r = put_user(c, (uint8_t __user *) addr)))
+				return r;
+
+			cnt++;
+		}
+
+	}
+	return r;
+}
+
+int do_ls_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	int r;
+	u64 data1[2] = {0,0};
+	u64 data2[2] = {0,0};
+	//desc->decodedtime = ktime_get_ns();
+	// the reg indices have to always be valid, even if the reg isn't being used
+	if (!desc->load) {
+		if (desc->simd) {
+			// At least currently, there aren't any simd instructions supported that use more than one data register
+			//__uint128_t tmp;
+
+			// probably better for performance to read both registers with one function to kernel_neon_* doesn't have to be called more than once
+			read_simd_reg(desc->reg1, data1);
+			read_simd_reg(desc->reg2, data2);
+			//data1[0] = tmp;
+			//data1[1] = *(((u64*)&tmp) + 1);
+			///printk("SIMD: storing 0x%llx %llx (%d bits) at 0x%px", data1[1], data1[0], desc->width, desc->addr);
+			/*if (desc->width < 128) {
+				return -1;
+			}*/
+		} else {
+			data1[0] = regs->regs[desc->reg1];
+			data2[0] = regs->regs[desc->reg2];
+		}
+	}
+
+	/*if (desc->width > 64) {
+		printk("Currently cannot process ls_fixup with a size of %d bits\n", desc->width);
+		return 1;
+	}*/
+	if (!desc->load) {
+		uint8_t *addr = desc->addr;
+		int bcount = desc->width / 8;	// since the field stores the width in bits. Honestly, there's no particular reason for that
+
+		//printk("Storing %d bytes (pair: %d) to 0x%llx",bcount, desc->pair, desc->addr);
+		int addrIt = 0;
+		for (int i = 0; i < bcount; i++) {
+			if ((r=put_user( (*(((uint8_t *)(data1)) + addrIt) & 0xff), (uint8_t __user *)addr)))
+				return r;
+
+			//desc->data1 >>= 8;
+			addrIt++;
+			addr++;
+		}
+		//put_data2(bcount, (uint8_t*)data1, addr);
+		//addr += bcount;
+		addrIt = 0;
+		if (desc->pair) {
+			for (int i = 0; i < bcount; i++) {
+				if ((r=put_user((*(((uint8_t *)(data2)) + addrIt) & 0xff) & 0xff, (uint8_t __user *)addr)))
+					return r;
+
+				//desc->data2 >>= 8;
+				addrIt++;
+				addr++;
+			}
+			//put_data2(bcount, (uint8_t*)data2, addr);
+			addr += bcount;
+		}
+		arm64_skip_faulting_instruction(regs, 4);
+	} else {
+		//printk("Loading is currently not implemented (addr 0x%px)\n", desc->addr);
+
+		uint8_t *addr = desc->addr;
+		int bcount = desc->width / 8;	// since the field stores the width in bits. Honestly, there's no particular reason for that
+
+		//printk("Storing %d bytes (pair: %d) to 0x%llx",bcount, desc->pair, desc->addr);
+		int addrIt = 0;
+		/*for (int i = 0; i < bcount; i++) {
+			uint8_t val;
+			if ((r=get_user( val, (uint8_t __user *)addr))) {
+				printk("Failed to write data at 0x%px (base was 0x%px)\n", addr, desc->addr);
+				return r;
+			}
+			*(((uint8_t*)data1) + addrIt) = val;
+			//desc->data1 >>= 8;
+			addrIt++;
+			addr++;
+		}*/
+		get_data2(bcount, (uint8_t *)data1, addr);
+		addr += bcount;
+
+		if (desc->simd) {
+			write_simd_reg(desc->reg1, data1);
+		} else {
+			regs->regs[desc->reg1] = data1[0];
+		}
+
+		addrIt = 0;
+		if (desc->pair) {
+			/*for (int i = 0; i < bcount; i++) {
+				uint8_t val;
+				if ((r=get_user(val, (uint8_t __user *)addr))) {
+					printk("Failed to write data at 0x%px (base was 0x%px)\n", addr, desc->addr);
+					return r;
+				}
+				*(((uint8_t*)data2) + addrIt) = val;
+				//desc->data2 >>= 8;
+				addrIt++;
+				addr++;
+			}*/
+
+			get_data2(bcount, (uint8_t *)data2, addr);
+			addr += bcount;
+			if (desc->simd) {
+				write_simd_reg(desc->reg2, data1);
+			} else {
+				regs->regs[desc->reg2] = data1[0];
+			}
+		}
+		arm64_skip_faulting_instruction(regs, 4);
+	}
+	return 0;
+}
+
+int ls_cas_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t size = (instr >> 30) & 3;
+	uint8_t load = (instr >> 22) & 1;	// acquire semantics, has no effect here, since it's not atomic anymore
+	uint8_t Rs = (instr >> 16) & 0x1f;
+	uint8_t Rt2 = (instr >> 10) & 0x1f;
+	uint8_t Rn = (instr >> 5) & 0x1f;
+	uint8_t Rt = instr & 0x1f;
+
+	uint8_t o0 = (instr >> 15) & 1;	// L, release semantics, has no effect here, since it's not atomic anymore
+
+	if (Rt2 != 0x1f)
+		return -1;
+
+	switch(size) {
+	case 0:
+		desc->width = 8;
+		break;
+	case 1:
+		desc->width = 16;
+		break;
+	case 2:
+		desc->width = 32;
+		break;
+	case 3:
+		desc->width = 64;
+		break;
+	}
+
+	desc->addr = (void *)regs->regs[Rn];
+	u64 data1 = regs->regs[Rt];
+
+	// nearly everything from here on could be moved into another function if needed
+	u64 cmpmask = (1 << desc->width) - 1;
+	u64 cmpval = regs->regs[Rs] & cmpmask;
+
+	u64 readval = 0;
+	int bcount = desc->width / 8;
+	u64 addr = desc->addr;
+	int r;
+	uint8_t  tmp;
+
+	printk("Atomic CAS not being done atomically at 0x%px, size %d\n", desc->addr, desc->width);
+
+	for (int i = 0; i < bcount; i++) {
+		if ((r=get_user(tmp, (uint8_t __user *)addr)))
+			return r;
+		readval |= tmp;
+		readval <<= 8;	// maybe this could be read directly into regs->regs[Rs]
+		addr++;
+	}
+
+	if ((readval & cmpmask) == cmpval) {
+		// swap
+		addr = (u64)desc->addr;
+
+		for (int i = 0; i < bcount; i++) {
+			if ((r=put_user(data1 & 0xff, (uint8_t __user *)addr)))
+				return r;
+			data1 >>= 8;
+			addr++;
+		}
+
+		regs->regs[Rs] = readval;
+	}
+
+	arm64_skip_faulting_instruction(regs, 4);
+
+	return 0;
+}
+
+__always_inline int ls_pair_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t op2;
+	uint8_t opc;
+	op2 = (instr >> 23) & 3;
+	opc = (instr >> 30) & 3;
+
+	uint8_t load = (instr >> 22) & 1;
+	uint8_t simd = (instr >> 26) & 1;
+	uint16_t imm7 = (instr >> 15) & 0x7f;
+	uint8_t Rt2 = (instr >> 10) & 0x1f;
+	uint8_t Rn = (instr >> 5) & 0x1f;
+	uint8_t Rt = instr & 0x1f;
+
+	int64_t imm = extend_sign(imm7, 7);
+	//int immshift = 0;
+	desc->load = load;
+	desc->simd = simd;
+
+	// opc controls the width
+	if (simd) {
+		desc->width = 32 << opc;
+		//immshift = 4 << opc;
+		imm <<= 2;
+		imm <<= opc;
+	} else {
+		switch(opc) {
+		case 0:
+			desc->width = 32;
+			imm <<= 2;
+			break;
+		case 2:
+			desc->width = 64;
+			imm <<= 3;
+			break;
+		default:
+			return -1;
+		}
+	}
+
+	// op2 controls the indexing
+	switch(op2) {
+	case 2:
+		// offset
+		desc->addr = (void *)(regs->regs[Rn] + imm);
+		break;
+	default:
+		return -1;
+	}
+	//desc->data1 = regs->regs[Rt];
+	//desc->data2 = regs->regs[Rt2];
+	desc->reg1 = Rt;
+	desc->reg2 = Rt2;
+
+	return do_ls_fixup(instr, regs, desc);
+
+}
+
+__always_inline int ls_reg_unsigned_imm(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t size = (instr >> 30) & 3;
+	uint8_t simd = (instr >> 26) & 1;
+	uint8_t opc = (instr >> 22) & 3;
+	uint64_t imm12 = (instr >> 10) & 0xfff;
+	uint8_t Rn = (instr >> 5) & 0x1f;
+	uint8_t Rt = instr & 0x1f;
+
+	uint8_t load = opc & 1;
+	uint8_t extend_sign = 0;// = ((opc & 2) >> 1 ) & !simd;
+	int width_shift = 0;
+
+	if (simd) {
+		extend_sign = 0;
+		width_shift = size | ((opc & 2) << 1);
+	} else {
+		extend_sign = ((opc & 2) >> 1 );
+		width_shift = size;
+	}
+
+	///printk("size: %d simd: %d opc: %d imm12: 0x%x Rn: %d Rt: %d\n", size, simd, opc, imm12, Rn, Rt);
+	// when in simd mode, opc&2 is a third size bit. Otherwise, it's there for sign extension
+	//width_shift = (size | (((opc & 2) & (simd << 1)) << 1));
+	desc->width = 8 << width_shift;
+
+	if ((size & 1) && simd && (opc & 2))
+		return 1;
+
+	desc->load = load;
+	desc->reg1 = Rt;
+	desc->simd = simd;
+	desc->extendSign = extend_sign;
+	u64 addr = regs->regs[Rn];
+	desc->addr = addr + (imm12 << width_shift);
+
+	return do_ls_fixup(instr, regs, desc);
+}
+
+
+__always_inline u64 extend_reg(u64 reg, int type, int shift)
+{
+	uint8_t is_signed = (type & 4) >> 2;
+	uint8_t input_width = type & 1;
+
+	u64 tmp;
+
+	if (!is_signed) {
+		tmp = reg;
+	} else {
+		if (input_width == 0) {
+			// 32bit, needs to be extended to 64
+			// I hope the compiler just does this kind of automatically with these types
+			int32_t stmpw = reg;
+			int64_t stmpdw = stmpw;
+			tmp = (u64)stmpdw;
+		} else {
+			printk("Other branch I forgor about previously!\n");
+			tmp = reg;	// since the size stays the same, I don't think this makes a difference
+		}
+	}
+
+	///printk("extend_reg: reg 0x%lx out (before shift) 0x%lx signed: %x\n", reg, tmp, is_signed);
+
+	return tmp << shift;
+}
+
+__always_inline int lsr_offset_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t size = (instr >> 30) & 3;
+	uint8_t simd = (instr >> 26) & 1;
+	uint8_t opc = (instr >> 22) & 3;
+	uint8_t option = (instr >> 13) & 5;
+	uint8_t Rm = (instr >> 16) & 0x1f;
+	uint8_t Rn = (instr >> 5) & 0x1f;
+	uint8_t Rt = instr & 0x1f;
+	uint8_t S = (instr >> 12) & 1;
+	int width_shift = (size | (((opc & 2) & (simd << 1)) << 1));
+	// size==0 seems to be a bit special
+	// opc&2 is sign, opc&1 is load	(for most instructions anyways)
+
+	uint8_t load = opc & 1;
+	uint8_t extend_sign = ((opc & 2) >> 1 ) & !simd;
+	desc->pair = 0;
+
+	desc->simd = simd;
+	desc->width = 8 << width_shift;
+
+	// the simd instructions make this a bit weird
+	if (extend_sign) {
+		if (load) {
+			desc->extend_width = 32;
+		} else {
+			desc->extend_width = 64;
+		}
+		desc->load = 1;
+	} else {
+		desc->load = load;
+	}
+
+	desc->extendSign = extend_sign;	// needed for load, which isn't implemented yet
+
+	u64 offset = 0;
+	u64 addr = 0;
+	addr = regs->regs[Rn];
+	if (simd) {
+		int shift = 0;
+		if (S) shift = width_shift;
+		offset = extend_reg(regs->regs[Rm], option, shift);
+	} else {
+		int shift = 0;
+		if (S) shift = 2 << ((size & 1) & ((size >> 1) & 1));
+
+		offset = extend_reg(regs->regs[Rm], option, shift);
+	}
+
+	addr += offset;
+
+	//desc->data1 = regs->regs[Rt];
+	desc->reg1 = Rt;
+	desc->addr = (void *)addr;
+
+	return do_ls_fixup(instr, regs, desc);
+	return 0;
+}
+
+__always_inline int lsr_unscaled_immediate_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t size = (instr >> 30) & 3;
+	uint8_t simd = (instr >> 26) & 1;
+	uint8_t opc = (instr >> 22) & 3;
+	uint16_t imm9 = (instr >> 12) & 0x1ff;
+	uint8_t Rn = (instr >> 5) & 0x1f;
+	uint8_t Rt = instr & 0x1f;
+
+	int16_t fullImm = 0;
+	// sign extend it
+	if (imm9 & 0x100) {
+		fullImm = 0xfe00 | imm9;
+	} else {
+		fullImm = imm9;
+	}
+	u64 addr = regs->regs[Rn];
+	desc->addr = addr + fullImm;
+	desc->pair = 0;
+
+	int load = opc & 1;
+	desc->load = load;
+	/*if (load) {
+		return 1;
+	}*/
+	desc->reg1 = Rt;
+	if (simd) {
+		desc->simd = 1;
+		desc->width = 8 << (size | ((opc & 2) << 1));
+		// assuming store
+		/*__uint128_t tmp;
+		read_simd_reg(Rt, &tmp);
+		desc->data1 = tmp;
+		desc->data1_simd = *(((u64*)&tmp) + 1);*/
+		return do_ls_fixup(instr, regs, desc);
+	} else {
+		desc->simd = 0;
+		desc->width = 8 << size;
+		return do_ls_fixup(instr, regs, desc);
+	}
+	///printk("SIMD: %d\n", simd);
+	return 1;
+}
+
+__always_inline int ls_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t op0;
+	uint8_t op1;
+	uint8_t op2;
+	uint8_t op3;
+	uint8_t op4;
+
+	int r = 1;
+
+	op0 = (instr >> 28) & 0xf;
+	op1 = (instr >> 26) & 1;
+	op2 = (instr >> 23) & 3;
+	op3 = (instr >> 16) & 0x3f;
+	op4 = (instr >> 10) & 3;
+
+	if ((op0 & 3) == 2) {
+		desc->pair = 1;
+		r = ls_pair_fixup(instr, regs, desc);
+	}
+	if ((op0 & 3) == 0 && op1 == 0 && op2 == 1 && (op3 & 0x20) == 0x20) {
+		// compare and swap
+		r = ls_cas_fixup(instr, regs, desc);
+	}
+	if ((op0 & 3) == 3 && (op2 & 3) == 3) {
+		//load/store unsigned immediate
+		desc->pair = 0;
+
+	}
+	if ((op0 & 3) == 3 && ((op2 & 2) == 2)) {
+		// register unsigned immediate
+		r = ls_reg_unsigned_imm(instr, regs, desc);
+	}
+	if ((op0 & 3) == 3 && (op2 & 2) == 0 && (op3 & 0x20) == 0x20 && op4 == 2) {
+		// register offset load/store
+		r = lsr_offset_fixup(instr, regs, desc);
+	}
+	if ((op0 & 3) == 3 && (op2 & 2) == 0 && (op3 & 0x20) == 0x0 && op4 == 0) {
+		// register load/store unscaled immediate
+		r = lsr_unscaled_immediate_fixup(instr, regs, desc);
+	}
+	if (r) {
+		printk("Load/Store: op0 0x%x op1 0x%x op2 0x%x op3 0x%x op4 0x%x\n", op0, op1, op2, op3, op4);
+	}
+	return r;
+}
+
+__always_inline int system_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t op1;
+	uint8_t op2;
+	uint8_t CRn;
+	uint8_t CRm;
+	uint8_t Rt;
+	bool L;
+	int r = 0;
+
+	op1 = (instr >> 16) & 0x7;
+	op2 = (instr >> 5) & 0x7;
+	CRn = (instr >> 12) & 0xf;
+	CRm = (instr >> 8) & 0xf;
+	L = (instr >> 21) & 1;
+	Rt = instr & 0x1f;
+
+	if (!L) {
+		// SYS
+		// proper decoding would be nicer here, but I don't expect to see too many system instructions
+		if ((op1 == 0x3) && (op2 == 1) && (CRn = 0x7) && (CRm == 4)) {
+			// dc zva
+			uint64_t dczid_el0 = read_sysreg_s(SYS_DCZID_EL0);
+			if (!((dczid_el0 >> DCZID_EL0_DZP_SHIFT) & 1)) {
+				uint16_t blksize = 4 << (dczid_el0 & 0xf);
+				r = memset_io_user(blksize, 0, regs->user_regs.regs[Rt]);
+				arm64_skip_faulting_instruction(regs, 4);
+				return r;
+			} else {
+				printk("DC ZVA is not allowed!\n");
+				return 1;
+			}
+		}
+	}
+
+	printk("Unhandled system instruction. op1=0x%x op2=0x%x CRn=0x%x CRm=0x%x\n", op1, op2, CRn, CRm);
+	return 1;
+}
+
+__always_inline int branch_except_system_fixup(u32 instr, struct pt_regs *regs, struct fixupDescription *desc)
+{
+	uint8_t op0;
+	uint32_t op1;
+	uint8_t op2;
+
+	op0 = (instr >> 29) & 0x7;
+	op1 = (instr >> 5) & 0x1fffff;
+	op2 = instr & 0x1f;
+
+	if ((op0 == 0x6) && (op1 & 0x1ec000) == 0x84000)
+		return system_fixup(instr, regs, desc);
+
+	printk("Unhandled Branch/Exception generating/System instruction. op0=0x%x op1=0x%x op2=0x%x\n", op0, op1, op2);
+	return 1;
+}
+
+uint32_t *seenCMDs;
+size_t seenCMDCount = 0;
+size_t seenCMDSize = 0;
+
+void instrDBG(u32 instr)
+{
+	for(size_t i = 0; i < seenCMDCount; i++) {
+		if (seenCMDs[i] == instr)
+			return;
+	}
+	if (seenCMDSize == 0) {
+		seenCMDs = krealloc(seenCMDs, 1, GFP_KERNEL);
+		seenCMDSize = 1;
+	}
+
+	if (seenCMDCount >= seenCMDSize) {
+		seenCMDs = krealloc(seenCMDs, seenCMDSize*2, GFP_KERNEL);
+		seenCMDSize *= 2;
+	}
+
+	seenCMDs[seenCMDCount] = instr;
+	seenCMDCount++;
+	printk("New instruction: %x", instr);
+}
+
+int do_alignment_fixup(unsigned long addr, struct pt_regs *regs)
+{
+	unsigned long long instrptr;
+	u32 instr = 0;
+
+	instrptr = instruction_pointer(regs);
+	//printk("Alignment fixup\n");
+
+	if (alignment_get_arm64(regs, (__le64 __user *)instrptr, &instr)) {
+		printk("Failed to get aarch64 instruction\n");
+		return 1;
+	}
+
+	/**
+	 * List of seen faults: 020c00a9 (0xa9000c02) stp x2, x3, [x0]
+	 *
+	 */
+
+	//instrDBG(instr);
+
+	uint8_t op0;
+	int r;
+	struct fixupDescription desc = {0};
+	//desc.starttime = ktime_get_ns();
+	op0 = ((instr & 0x1E000000) >> 25);
+	if ((op0 & 5) == 0x4) {
+		//printk("Load/Store\n");
+		r = ls_fixup(instr, regs, &desc);
+		//desc.endtime = ktime_get_ns();
+		/*printk("Trap timing: decoding: %ldns, mem ops: %ldns, total: %ldns\n", desc.decodedtime - desc.starttime,
+				desc.endtime - desc.decodedtime, desc.endtime - desc.starttime);
+				*/
+		if (r)
+			printk("Faulting instruction: 0x%lx\n", instr);
+
+		return r;
+	} else if ((op0 & 0xe) == 0xa) {
+		// System instructions, needed for dc zva
+		return branch_except_system_fixup(instr, regs, &desc);
+	} else {
+		printk("Not handling instruction with op0 0x%x (instruction is 0x%08x)", op0, instr);
+	}
+	return -1;
+}

--- a/arch/arm64/mm/fault.c
+++ b/arch/arm64/mm/fault.c
@@ -25,6 +25,7 @@
 #include <linux/perf_event.h>
 #include <linux/preempt.h>
 #include <linux/hugetlb.h>
+#include <linux/nmi.h>
 
 #include <asm/acpi.h>
 #include <asm/bug.h>
@@ -674,6 +675,7 @@ done:
 		 * We had some memory, but were unable to successfully fix up
 		 * this page fault.
 		 */
+		printk("Page fault bus error\n");
 		arm64_force_sig_fault(SIGBUS, BUS_ADRERR, far, inf->name);
 	} else if (fault & (VM_FAULT_HWPOISON_LARGE | VM_FAULT_HWPOISON)) {
 		unsigned int lsb;
@@ -717,8 +719,16 @@ static int do_alignment_fault(unsigned long far, unsigned long esr,
 			      struct pt_regs *regs)
 {
 	if (IS_ENABLED(CONFIG_COMPAT_ALIGNMENT_FIXUPS) &&
-	    compat_user_mode(regs))
+		compat_user_mode(regs))
 		return do_compat_alignment_fixup(far, regs);
+
+	if (IS_ENABLED(CONFIG_ARM64_ALIGNMENT_FIXUPS) && user_mode(regs)) {
+		// aarch64 user mode
+		if (do_alignment_fixup(far, regs) == 0)
+			return 0;
+
+		printk("Unfixed alignment issue\n");
+	}
 	do_bad_area(far, esr, regs);
 	return 0;
 }

--- a/drivers/gpu/drm/Kconfig
+++ b/drivers/gpu/drm/Kconfig
@@ -30,6 +30,16 @@ menuconfig DRM
 	  details.  You should also select and configure AGP
 	  (/dev/agpgart) support if it is available for your platform.
 
+config DRM_ARCH_CAN_WC
+    bool "Force Architecture can write-combine memory"
+    depends on DRM
+    default n
+    help
+      Enables write-combining even if it is not enabled by default.
+      Only use if the target systems support write-combining on
+      the memory used by the graphics adapters.
+      If in doubt, say 'N'
+
 config DRM_MIPI_DBI
 	tristate
 	depends on DRM

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_cs.c
@@ -1055,7 +1055,7 @@ static int amdgpu_cs_patch_ibs(struct amdgpu_cs_parser *p,
 		kptr += va_start - (m->start * AMDGPU_GPU_PAGE_SIZE);
 
 		if (ring->funcs->parse_cs) {
-			memcpy(ib->ptr, kptr, ib->length_dw * 4);
+			memcpy_fromio(ib->ptr, kptr, ib->length_dw * 4);
 			amdgpu_bo_kunmap(aobj);
 
 			r = amdgpu_ring_parse_cs(ring, p, job, ib);

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
@@ -1048,7 +1048,7 @@ static int amdgpu_device_wb_init(struct amdgpu_device *adev)
 		memset(&adev->wb.used, 0, sizeof(adev->wb.used));
 
 		/* clear wb memory */
-		memset((char *)adev->wb.wb, 0, AMDGPU_MAX_WB * sizeof(uint32_t) * 8);
+		memset_io((char *)adev->wb.wb, 0, AMDGPU_MAX_WB * sizeof(uint32_t) * 8);
 	}
 
 	return 0;

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_gfx.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_gfx.c
@@ -364,7 +364,7 @@ int amdgpu_gfx_kiq_init(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memset(hpd, 0, hpd_size);
+	memset_io(hpd, 0, hpd_size);
 
 	r = amdgpu_bo_reserve(kiq->eop_obj, true);
 	if (unlikely(r != 0))

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_mes.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_mes.c
@@ -240,7 +240,7 @@ int amdgpu_mes_create_process(struct amdgpu_device *adev, int pasid,
 		DRM_ERROR("failed to allocate process context bo\n");
 		goto clean_up_memory;
 	}
-	memset(process->proc_ctx_cpu_ptr, 0, AMDGPU_MES_PROC_CTX_SIZE);
+	memset_io(process->proc_ctx_cpu_ptr, 0, AMDGPU_MES_PROC_CTX_SIZE);
 
 	/*
 	 * Avoid taking any other locks under MES lock to avoid circular
@@ -364,7 +364,7 @@ int amdgpu_mes_add_gang(struct amdgpu_device *adev, int pasid,
 		DRM_ERROR("failed to allocate process context bo\n");
 		goto clean_up_mem;
 	}
-	memset(gang->gang_ctx_cpu_ptr, 0, AMDGPU_MES_GANG_CTX_SIZE);
+	memset_io(gang->gang_ctx_cpu_ptr, 0, AMDGPU_MES_GANG_CTX_SIZE);
 
 	/*
 	 * Avoid taking any other locks under MES lock to avoid circular
@@ -522,7 +522,7 @@ static int amdgpu_mes_queue_alloc_mqd(struct amdgpu_device *adev,
 		dev_warn(adev->dev, "failed to create queue mqd bo (%d)", r);
 		return r;
 	}
-	memset(q->mqd_cpu_ptr, 0, mqd_size);
+	memset_io(q->mqd_cpu_ptr, 0, mqd_size);
 
 	r = amdgpu_bo_reserve(q->mqd_obj, false);
 	if (unlikely(r != 0))
@@ -1129,7 +1129,7 @@ int amdgpu_mes_ctx_alloc_meta_data(struct amdgpu_device *adev,
 	if (!ctx_data->meta_data_obj)
 		return -ENOMEM;
 
-	memset(ctx_data->meta_data_ptr, 0,
+	memset_io(ctx_data->meta_data_ptr, 0,
 	       sizeof(struct amdgpu_mes_ctx_meta_data));
 
 	return 0;

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_psp.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_psp.c
@@ -633,9 +633,9 @@ psp_cmd_submit_buf(struct psp_context *psp,
 	if (psp->adev->no_hw_access)
 		return 0;
 
-	memset(psp->cmd_buf_mem, 0, PSP_CMD_BUFFER_SIZE);
+	memset_io(psp->cmd_buf_mem, 0, PSP_CMD_BUFFER_SIZE);
 
-	memcpy(psp->cmd_buf_mem, cmd, sizeof(struct psp_gfx_cmd_resp));
+	memcpy_toio(psp->cmd_buf_mem, cmd, sizeof(struct psp_gfx_cmd_resp));
 
 	index = atomic_inc_return(&psp->fence_value);
 	ret = psp_ring_cmd_submit(psp, psp->cmd_buf_mc_addr, fence_mc_addr, index);
@@ -664,7 +664,7 @@ psp_cmd_submit_buf(struct psp_context *psp,
 	skip_unsupport = (psp->cmd_buf_mem->resp.status == TEE_ERROR_NOT_SUPPORTED ||
 		psp->cmd_buf_mem->resp.status == PSP_ERR_UNKNOWN_COMMAND) && amdgpu_sriov_vf(psp->adev);
 
-	memcpy(&cmd->resp, &psp->cmd_buf_mem->resp, sizeof(struct psp_gfx_resp));
+	memcpy_fromio(&cmd->resp, &psp->cmd_buf_mem->resp, sizeof(struct psp_gfx_resp));
 
 	/* In some cases, psp response status is not 0 even there is no
 	 * problem while the command is submitted. Some version of PSP FW
@@ -992,8 +992,8 @@ static int psp_rl_load(struct amdgpu_device *adev)
 
 	cmd = acquire_psp_cmd_buf(psp);
 
-	memset(psp->fw_pri_buf, 0, PSP_1_MEG);
-	memcpy(psp->fw_pri_buf, psp->rl.start_addr, psp->rl.size_bytes);
+	memset_io(psp->fw_pri_buf, 0, PSP_1_MEG);
+	memcpy_toio(psp->fw_pri_buf, psp->rl.start_addr, psp->rl.size_bytes);
 
 	cmd->cmd_id = GFX_CMD_ID_LOAD_IP_FW;
 	cmd->cmd.cmd_load_ip_fw.fw_phy_addr_lo = lower_32_bits(psp->fw_pri_mc_addr);
@@ -2628,7 +2628,7 @@ static int psp_load_fw(struct amdgpu_device *adev)
 		/* should not destroy ring, only stop */
 		psp_ring_stop(psp, PSP_RING_TYPE__KM);
 	} else {
-		memset(psp->fence_buf, 0, PSP_FENCE_BUFFER_SIZE);
+		memset_io(psp->fence_buf, 0, PSP_FENCE_BUFFER_SIZE);
 
 		ret = psp_ring_init(psp, PSP_RING_TYPE__KM);
 		if (ret) {
@@ -2974,7 +2974,7 @@ int psp_ring_cmd_submit(struct psp_context *psp,
 	}
 
 	/* Initialize KM RB frame */
-	memset(write_frame, 0, sizeof(struct psp_gfx_rb_frame));
+	memset_io(write_frame, 0, sizeof(struct psp_gfx_rb_frame));
 
 	/* Update KM RB frame */
 	write_frame->cmd_buf_addr_hi = upper_32_bits(cmd_buf_mc_addr);
@@ -3574,8 +3574,8 @@ void psp_copy_fw(struct psp_context *psp, uint8_t *start_addr, uint32_t bin_size
 	if (!drm_dev_enter(adev_to_drm(psp->adev), &idx))
 		return;
 
-	memset(psp->fw_pri_buf, 0, PSP_1_MEG);
-	memcpy(psp->fw_pri_buf, start_addr, bin_size);
+	memset_io(psp->fw_pri_buf, 0, PSP_1_MEG);
+	memcpy_toio(psp->fw_pri_buf, start_addr, bin_size);
 
 	drm_dev_exit(idx);
 }

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_sa.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_sa.c
@@ -58,7 +58,7 @@ int amdgpu_sa_bo_manager_init(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memset(sa_manager->cpu_ptr, 0, size);
+	memset_io(sa_manager->cpu_ptr, 0, size);
 	drm_suballoc_manager_init(&sa_manager->base, size, suballoc_align);
 	return r;
 }

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ttm.c
@@ -1103,7 +1103,7 @@ static struct ttm_tt *amdgpu_ttm_tt_create(struct ttm_buffer_object *bo,
 	if (abo->flags & AMDGPU_GEM_CREATE_CPU_GTT_USWC)
 		caching = ttm_write_combined;
 	else
-		caching = ttm_cached;
+		caching = ttm_uncached;
 
 	/* allocate space for the uninitialized page entries */
 	if (ttm_sg_tt_init(&gtt->ttm, bo, page_flags, caching)) {

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_ucode.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_ucode.c
@@ -962,7 +962,7 @@ static int amdgpu_ucode_init_single_fw(struct amdgpu_device *adev,
 			le32_to_cpu(header->ucode_array_offset_bytes);
 	}
 
-	memcpy(ucode->kaddr, ucode_addr, ucode->ucode_size);
+	memcpy_toio(ucode->kaddr, ucode_addr, ucode->ucode_size);
 
 	return 0;
 }
@@ -986,7 +986,7 @@ static int amdgpu_ucode_patch_jt(struct amdgpu_firmware_info *ucode,
 	src_addr = (uint8_t *)ucode->fw->data +
 			   le32_to_cpu(comm_hdr->ucode_array_offset_bytes) +
 			   (le32_to_cpu(header->jt_offset) * 4);
-	memcpy(dst_addr, src_addr, le32_to_cpu(header->jt_size) * 4);
+	memcpy_toio(dst_addr, src_addr, le32_to_cpu(header->jt_size) * 4);
 
 	return 0;
 }
@@ -1003,7 +1003,7 @@ int amdgpu_ucode_create_bo(struct amdgpu_device *adev)
 			dev_err(adev->dev, "failed to create kernel buffer for firmware.fw_buf\n");
 			return -ENOMEM;
 		} else if (amdgpu_sriov_vf(adev)) {
-			memset(adev->firmware.fw_buf_ptr, 0, adev->firmware.fw_size);
+			memset_io(adev->firmware.fw_buf_ptr, 0, adev->firmware.fw_size);
 		}
 	}
 	return 0;

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_uvd.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_uvd.c
@@ -1196,7 +1196,7 @@ int amdgpu_uvd_get_create_msg(struct amdgpu_ring *ring, uint32_t handle,
 {
 	struct amdgpu_device *adev = ring->adev;
 	struct amdgpu_bo *bo = adev->uvd.ib_bo;
-	uint32_t *msg;
+	volatile uint32_t *msg;
 	int i;
 
 	msg = amdgpu_bo_kptr(bo);
@@ -1224,7 +1224,7 @@ int amdgpu_uvd_get_destroy_msg(struct amdgpu_ring *ring, uint32_t handle,
 {
 	struct amdgpu_device *adev = ring->adev;
 	struct amdgpu_bo *bo = NULL;
-	uint32_t *msg;
+	volatile uint32_t *msg;
 	int r, i;
 
 	if (direct) {

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_vcn.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_vcn.c
@@ -576,7 +576,7 @@ static int amdgpu_vcn_dec_get_create_msg(struct amdgpu_ring *ring, uint32_t hand
 		struct amdgpu_ib *ib)
 {
 	struct amdgpu_device *adev = ring->adev;
-	uint32_t *msg;
+	volatile uint32_t *msg;
 	int r, i;
 
 	memset(ib, 0, sizeof(*ib));
@@ -611,7 +611,7 @@ static int amdgpu_vcn_dec_get_destroy_msg(struct amdgpu_ring *ring, uint32_t han
 					  struct amdgpu_ib *ib)
 {
 	struct amdgpu_device *adev = ring->adev;
-	uint32_t *msg;
+	volatile uint32_t *msg;
 	int r, i;
 
 	memset(ib, 0, sizeof(*ib));
@@ -734,7 +734,7 @@ static int amdgpu_vcn_dec_sw_send_msg(struct amdgpu_ring *ring,
 	ib->ptr[ib->length_dw++] = cpu_to_le32(AMDGPU_VCN_IB_FLAG_DECODE_BUFFER);
 	decode_buffer = (struct amdgpu_vcn_decode_buffer *)&(ib->ptr[ib->length_dw]);
 	ib->length_dw += sizeof(struct amdgpu_vcn_decode_buffer) / 4;
-	memset(decode_buffer, 0, sizeof(struct amdgpu_vcn_decode_buffer));
+	memset_io(decode_buffer, 0, sizeof(struct amdgpu_vcn_decode_buffer));
 
 	decode_buffer->valid_buf_flag |= cpu_to_le32(AMDGPU_VCN_CMD_FLAG_MSG_BUFFER);
 	decode_buffer->msg_buffer_address_hi = cpu_to_le32(addr >> 32);

--- a/drivers/gpu/drm/amd/amdgpu/atom.c
+++ b/drivers/gpu/drm/amd/amdgpu/atom.c
@@ -57,7 +57,7 @@
 #define PLL_INDEX	2
 #define PLL_DATA	3
 
-#define ATOM_CMD_TIMEOUT_SEC	20
+#define ATOM_CMD_TIMEOUT_SEC	30
 
 typedef struct {
 	struct atom_context *ctx;

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v10_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v10_0.c
@@ -4213,7 +4213,7 @@ static int gfx_v10_0_mec_init(struct amdgpu_device *adev)
 			return r;
 		}
 
-		memset(hpd, 0, mec_hpd_size);
+		memset_io(hpd, 0, mec_hpd_size);
 
 		amdgpu_bo_kunmap(adev->gfx.mec.hpd_eop_obj);
 		amdgpu_bo_unreserve(adev->gfx.mec.hpd_eop_obj);
@@ -5314,10 +5314,10 @@ static void gfx_v10_0_rlc_backdoor_autoload_copy_ucode(struct amdgpu_device *ade
 	if (fw_size > toc_fw_size)
 		fw_size = toc_fw_size;
 
-	memcpy(ptr + toc_offset, fw_data, fw_size);
+	memcpy_toio(ptr + toc_offset, fw_data, fw_size);
 
 	if (fw_size < toc_fw_size)
-		memset(ptr + toc_offset + fw_size, 0, toc_fw_size - fw_size);
+		memset_io(ptr + toc_offset + fw_size, 0, toc_fw_size - fw_size);
 }
 
 static void gfx_v10_0_rlc_backdoor_autoload_copy_toc_ucode(struct amdgpu_device *adev)
@@ -6329,7 +6329,7 @@ static void gfx_v10_0_kiq_setting(struct amdgpu_ring *ring)
 }
 
 static void gfx_v10_0_gfx_mqd_set_priority(struct amdgpu_device *adev,
-					   struct v10_gfx_mqd *mqd,
+					   volatile struct v10_gfx_mqd *mqd,
 					   struct amdgpu_mqd_prop *prop)
 {
 	bool priority = 0;
@@ -6349,7 +6349,7 @@ static void gfx_v10_0_gfx_mqd_set_priority(struct amdgpu_device *adev,
 static int gfx_v10_0_gfx_mqd_init(struct amdgpu_device *adev, void *m,
 				  struct amdgpu_mqd_prop *prop)
 {
-	struct v10_gfx_mqd *mqd = m;
+	volatile struct v10_gfx_mqd *mqd = m;
 	uint64_t hqd_gpu_addr, wb_gpu_addr;
 	uint32_t tmp;
 	uint32_t rb_bufsz;
@@ -6436,7 +6436,7 @@ static int gfx_v10_0_gfx_init_queue(struct amdgpu_ring *ring)
 	int mqd_idx = ring - &adev->gfx.gfx_ring[0];
 
 	if (!amdgpu_in_reset(adev) && !adev->in_suspend) {
-		memset((void *)mqd, 0, sizeof(*mqd));
+		memset_io((void *)mqd, 0, sizeof(*mqd));
 		mutex_lock(&adev->srbm_mutex);
 		nv_grbm_select(adev, ring->me, ring->pipe, ring->queue, 0);
 		amdgpu_ring_init_mqd(ring);
@@ -6499,7 +6499,7 @@ static int gfx_v10_0_cp_async_gfx_ring_resume(struct amdgpu_device *adev)
 static int gfx_v10_0_compute_mqd_init(struct amdgpu_device *adev, void *m,
 				      struct amdgpu_mqd_prop *prop)
 {
-	struct v10_compute_mqd *mqd = m;
+	volatile struct v10_compute_mqd *mqd = m;
 	uint64_t hqd_gpu_addr, wb_gpu_addr, eop_base_addr;
 	uint32_t tmp;
 
@@ -6742,7 +6742,7 @@ static int gfx_v10_0_kiq_init_queue(struct amdgpu_ring *ring)
 		nv_grbm_select(adev, 0, 0, 0, 0);
 		mutex_unlock(&adev->srbm_mutex);
 	} else {
-		memset((void *)mqd, 0, sizeof(*mqd));
+		memset_io((void *)mqd, 0, sizeof(*mqd));
 		if (amdgpu_sriov_vf(adev) && adev->in_suspend)
 			amdgpu_ring_clear_ring(ring);
 		mutex_lock(&adev->srbm_mutex);
@@ -6766,7 +6766,7 @@ static int gfx_v10_0_kcq_init_queue(struct amdgpu_ring *ring)
 	int mqd_idx = ring - &adev->gfx.compute_ring[0];
 
 	if (!amdgpu_in_reset(adev) && !adev->in_suspend) {
-		memset((void *)mqd, 0, sizeof(*mqd));
+		memset_io((void *)mqd, 0, sizeof(*mqd));
 		mutex_lock(&adev->srbm_mutex);
 		nv_grbm_select(adev, ring->me, ring->pipe, ring->queue, 0);
 		amdgpu_ring_init_mqd(ring);

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v11_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v11_0.c
@@ -747,7 +747,7 @@ static int gfx_v11_0_mec_init(struct amdgpu_device *adev)
 			return r;
 		}
 
-		memset(hpd, 0, mec_hpd_size);
+		memset_io(hpd, 0, mec_hpd_size);
 
 		amdgpu_bo_kunmap(adev->gfx.mec.hpd_eop_obj);
 		amdgpu_bo_unreserve(adev->gfx.mec.hpd_eop_obj);
@@ -1048,10 +1048,10 @@ static void gfx_v11_0_rlc_backdoor_autoload_copy_ucode(struct amdgpu_device *ade
 	if (fw_size > toc_fw_size)
 		fw_size = toc_fw_size;
 
-	memcpy(ptr + toc_offset, fw_data, fw_size);
+	memcpy_toio(ptr + toc_offset, fw_data, fw_size);
 
 	if (fw_size < toc_fw_size)
-		memset(ptr + toc_offset + fw_size, 0, toc_fw_size - fw_size);
+		memset_io(ptr + toc_offset + fw_size, 0, toc_fw_size - fw_size);
 
 	if ((id != SOC21_FIRMWARE_ID_RS64_PFP) && (id != SOC21_FIRMWARE_ID_RS64_ME))
 		*(uint64_t *)fw_autoload_mask |= 1ULL << id;
@@ -3595,7 +3595,7 @@ static void gfx_v11_0_cp_set_doorbell_range(struct amdgpu_device *adev)
 static int gfx_v11_0_gfx_mqd_init(struct amdgpu_device *adev, void *m,
 				  struct amdgpu_mqd_prop *prop)
 {
-	struct v11_gfx_mqd *mqd = m;
+	volatile struct v11_gfx_mqd *mqd = m;
 	uint64_t hqd_gpu_addr, wb_gpu_addr;
 	uint32_t tmp;
 	uint32_t rb_bufsz;
@@ -3685,7 +3685,7 @@ static int gfx_v11_0_gfx_init_queue(struct amdgpu_ring *ring)
 	int mqd_idx = ring - &adev->gfx.gfx_ring[0];
 
 	if (!amdgpu_in_reset(adev) && !adev->in_suspend) {
-		memset((void *)mqd, 0, sizeof(*mqd));
+		memset_io((void *)mqd, 0, sizeof(*mqd));
 		mutex_lock(&adev->srbm_mutex);
 		soc21_grbm_select(adev, ring->me, ring->pipe, ring->queue, 0);
 		amdgpu_ring_init_mqd(ring);
@@ -3739,7 +3739,7 @@ static int gfx_v11_0_cp_async_gfx_ring_resume(struct amdgpu_device *adev)
 static int gfx_v11_0_compute_mqd_init(struct amdgpu_device *adev, void *m,
 				      struct amdgpu_mqd_prop *prop)
 {
-	struct v11_compute_mqd *mqd = m;
+	volatile struct v11_compute_mqd *mqd = m;
 	uint64_t hqd_gpu_addr, wb_gpu_addr, eop_base_addr;
 	uint32_t tmp;
 
@@ -3997,7 +3997,7 @@ static int gfx_v11_0_kiq_init_queue(struct amdgpu_ring *ring)
 		soc21_grbm_select(adev, 0, 0, 0, 0);
 		mutex_unlock(&adev->srbm_mutex);
 	} else {
-		memset((void *)mqd, 0, sizeof(*mqd));
+		memset_io((void *)mqd, 0, sizeof(*mqd));
 		if (amdgpu_sriov_vf(adev) && adev->in_suspend)
 			amdgpu_ring_clear_ring(ring);
 		mutex_lock(&adev->srbm_mutex);
@@ -4021,7 +4021,7 @@ static int gfx_v11_0_kcq_init_queue(struct amdgpu_ring *ring)
 	int mqd_idx = ring - &adev->gfx.compute_ring[0];
 
 	if (!amdgpu_in_reset(adev) && !adev->in_suspend) {
-		memset((void *)mqd, 0, sizeof(*mqd));
+		memset_io((void *)mqd, 0, sizeof(*mqd));
 		mutex_lock(&adev->srbm_mutex);
 		soc21_grbm_select(adev, ring->me, ring->pipe, ring->queue, 0);
 		amdgpu_ring_init_mqd(ring);

--- a/drivers/gpu/drm/amd/amdgpu/mes_v10_1.c
+++ b/drivers/gpu/drm/amd/amdgpu/mes_v10_1.c
@@ -404,7 +404,7 @@ static int mes_v10_1_allocate_ucode_buffer(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memcpy(adev->mes.ucode_fw_ptr[pipe], fw_data, fw_size);
+	memcpy_toio(adev->mes.ucode_fw_ptr[pipe], fw_data, fw_size);
 
 	amdgpu_bo_kunmap(adev->mes.ucode_fw_obj[pipe]);
 	amdgpu_bo_unreserve(adev->mes.ucode_fw_obj[pipe]);
@@ -437,7 +437,7 @@ static int mes_v10_1_allocate_ucode_data_buffer(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memcpy(adev->mes.data_fw_ptr[pipe], fw_data, fw_size);
+	memcpy_toio(adev->mes.data_fw_ptr[pipe], fw_data, fw_size);
 
 	amdgpu_bo_kunmap(adev->mes.data_fw_obj[pipe]);
 	amdgpu_bo_unreserve(adev->mes.data_fw_obj[pipe]);
@@ -618,7 +618,7 @@ static int mes_v10_1_allocate_eop_buf(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memset(eop, 0, adev->mes.eop_gpu_obj[pipe]->tbo.base.size);
+	memset_io(eop, 0, adev->mes.eop_gpu_obj[pipe]->tbo.base.size);
 
 	amdgpu_bo_kunmap(adev->mes.eop_gpu_obj[pipe]);
 	amdgpu_bo_unreserve(adev->mes.eop_gpu_obj[pipe]);
@@ -628,11 +628,11 @@ static int mes_v10_1_allocate_eop_buf(struct amdgpu_device *adev,
 
 static int mes_v10_1_mqd_init(struct amdgpu_ring *ring)
 {
-	struct v10_compute_mqd *mqd = ring->mqd_ptr;
+	volatile struct v10_compute_mqd *mqd = ring->mqd_ptr;
 	uint64_t hqd_gpu_addr, wb_gpu_addr, eop_base_addr;
 	uint32_t tmp;
 
-	memset(mqd, 0, sizeof(*mqd));
+	memset_io(mqd, 0, sizeof(*mqd));
 
 	mqd->header = 0xC0310800;
 	mqd->compute_pipelinestat_enable = 0x00000001;
@@ -905,7 +905,7 @@ static int mes_v10_1_mqd_sw_init(struct amdgpu_device *adev,
 		dev_warn(adev->dev, "failed to create ring mqd bo (%d)", r);
 		return r;
 	}
-	memset(ring->mqd_ptr, 0, mqd_size);
+	memset_io(ring->mqd_ptr, 0, mqd_size);
 
 	/* prepare MQD backup */
 	adev->mes.mqd_backup[pipe] = kmalloc(mqd_size, GFP_KERNEL);

--- a/drivers/gpu/drm/amd/amdgpu/mes_v11_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/mes_v11_0.c
@@ -500,7 +500,7 @@ static int mes_v11_0_allocate_ucode_buffer(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memcpy(adev->mes.ucode_fw_ptr[pipe], fw_data, fw_size);
+	memcpy_toio(adev->mes.ucode_fw_ptr[pipe], fw_data, fw_size);
 
 	amdgpu_bo_kunmap(adev->mes.ucode_fw_obj[pipe]);
 	amdgpu_bo_unreserve(adev->mes.ucode_fw_obj[pipe]);
@@ -535,7 +535,7 @@ static int mes_v11_0_allocate_ucode_data_buffer(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memcpy(adev->mes.data_fw_ptr[pipe], fw_data, fw_size);
+	memcpy_toio(adev->mes.data_fw_ptr[pipe], fw_data, fw_size);
 
 	amdgpu_bo_kunmap(adev->mes.data_fw_obj[pipe]);
 	amdgpu_bo_unreserve(adev->mes.data_fw_obj[pipe]);
@@ -697,7 +697,7 @@ static int mes_v11_0_allocate_eop_buf(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memset(eop, 0,
+	memset_io(eop, 0,
 	       adev->mes.eop_gpu_obj[pipe]->tbo.base.size);
 
 	amdgpu_bo_kunmap(adev->mes.eop_gpu_obj[pipe]);
@@ -708,11 +708,11 @@ static int mes_v11_0_allocate_eop_buf(struct amdgpu_device *adev,
 
 static int mes_v11_0_mqd_init(struct amdgpu_ring *ring)
 {
-	struct v11_compute_mqd *mqd = ring->mqd_ptr;
+	volatile struct v11_compute_mqd *mqd = ring->mqd_ptr;
 	uint64_t hqd_gpu_addr, wb_gpu_addr, eop_base_addr;
 	uint32_t tmp;
 
-	memset(mqd, 0, sizeof(*mqd));
+	memset_io(mqd, 0, sizeof(*mqd));
 
 	mqd->header = 0xC0310800;
 	mqd->compute_pipelinestat_enable = 0x00000001;
@@ -1012,7 +1012,7 @@ static int mes_v11_0_mqd_sw_init(struct amdgpu_device *adev,
 		return r;
 	}
 
-	memset(ring->mqd_ptr, 0, mqd_size);
+	memset_io(ring->mqd_ptr, 0, mqd_size);
 
 	/* prepare MQD backup */
 	adev->mes.mqd_backup[pipe] = kmalloc(mqd_size, GFP_KERNEL);

--- a/drivers/gpu/drm/amd/amdgpu/psp_v13_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/psp_v13_0.c
@@ -215,10 +215,10 @@ static int psp_v13_0_bootloader_load_component(struct psp_context  	*psp,
 	if (ret)
 		return ret;
 
-	memset(psp->fw_pri_buf, 0, PSP_1_MEG);
+	memset_io(psp->fw_pri_buf, 0, PSP_1_MEG);
 
 	/* Copy PSP KDB binary to memory */
-	memcpy(psp->fw_pri_buf, bin_desc->start_addr, bin_desc->size_bytes);
+	memcpy_toio(psp->fw_pri_buf, bin_desc->start_addr, bin_desc->size_bytes);
 
 	/* Provide the PSP KDB to bootloader */
 	WREG32_SOC15(MP0, 0, regMP0_SMN_C2PMSG_36,
@@ -284,10 +284,10 @@ static int psp_v13_0_bootloader_load_sos(struct psp_context *psp)
 	if (ret)
 		return ret;
 
-	memset(psp->fw_pri_buf, 0, PSP_1_MEG);
+	memset_io(psp->fw_pri_buf, 0, PSP_1_MEG);
 
 	/* Copy Secure OS binary to PSP memory */
-	memcpy(psp->fw_pri_buf, psp->sos.start_addr, psp->sos.size_bytes);
+	memcpy_toio(psp->fw_pri_buf, psp->sos.start_addr, psp->sos.size_bytes);
 
 	/* Provide the PSP secure OS to bootloader */
 	WREG32_SOC15(MP0, 0, regMP0_SMN_C2PMSG_36,

--- a/drivers/gpu/drm/amd/amdgpu/psp_v13_0_4.c
+++ b/drivers/gpu/drm/amd/amdgpu/psp_v13_0_4.c
@@ -107,10 +107,10 @@ static int psp_v13_0_4_bootloader_load_component(struct psp_context  	*psp,
 	if (ret)
 		return ret;
 
-	memset(psp->fw_pri_buf, 0, PSP_1_MEG);
+	memset_io(psp->fw_pri_buf, 0, PSP_1_MEG);
 
 	/* Copy PSP KDB binary to memory */
-	memcpy(psp->fw_pri_buf, bin_desc->start_addr, bin_desc->size_bytes);
+	memcpy_toio(psp->fw_pri_buf, bin_desc->start_addr, bin_desc->size_bytes);
 
 	/* Provide the PSP KDB to bootloader */
 	WREG32_SOC15(MP0, 0, regMP0_SMN_C2PMSG_36,
@@ -170,10 +170,10 @@ static int psp_v13_0_4_bootloader_load_sos(struct psp_context *psp)
 	if (ret)
 		return ret;
 
-	memset(psp->fw_pri_buf, 0, PSP_1_MEG);
+	memset_io(psp->fw_pri_buf, 0, PSP_1_MEG);
 
 	/* Copy Secure OS binary to PSP memory */
-	memcpy(psp->fw_pri_buf, psp->sos.start_addr, psp->sos.size_bytes);
+	memcpy_toio(psp->fw_pri_buf, psp->sos.start_addr, psp->sos.size_bytes);
 
 	/* Provide the PSP secure OS to bootloader */
 	WREG32_SOC15(MP0, 0, regMP0_SMN_C2PMSG_36,

--- a/drivers/gpu/drm/amd/amdgpu/sdma_v6_0.c
+++ b/drivers/gpu/drm/amd/amdgpu/sdma_v6_0.c
@@ -817,7 +817,7 @@ static int sdma_v6_0_start(struct amdgpu_device *adev)
 static int sdma_v6_0_mqd_init(struct amdgpu_device *adev, void *mqd,
 			      struct amdgpu_mqd_prop *prop)
 {
-	struct v11_sdma_mqd *m = mqd;
+	volatile struct v11_sdma_mqd *m = mqd;
 	uint64_t wb_gpu_addr;
 
 	m->sdmax_rlcx_rb_cntl =

--- a/drivers/gpu/drm/amd/amdkfd/kfd_kernel_queue.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_kernel_queue.c
@@ -101,7 +101,7 @@ static bool kq_initialize(struct kernel_queue *kq, struct kfd_node *dev,
 		kq->eop_gpu_addr = kq->eop_mem->gpu_addr;
 		kq->eop_kernel_addr = kq->eop_mem->cpu_ptr;
 
-		memset(kq->eop_kernel_addr, 0, PAGE_SIZE);
+		memset_io(kq->eop_kernel_addr, 0, PAGE_SIZE);
 	}
 
 	retval = kfd_gtt_sa_allocate(dev, sizeof(*kq->rptr_kernel),
@@ -122,9 +122,9 @@ static bool kq_initialize(struct kernel_queue *kq, struct kfd_node *dev,
 	kq->wptr_kernel = kq->wptr_mem->cpu_ptr;
 	kq->wptr_gpu_addr = kq->wptr_mem->gpu_addr;
 
-	memset(kq->pq_kernel_addr, 0, queue_size);
-	memset(kq->rptr_kernel, 0, sizeof(*kq->rptr_kernel));
-	memset(kq->wptr_kernel, 0, dev->kfd->device_info.doorbell_size);
+	memset_io(kq->pq_kernel_addr, 0, queue_size);
+	memset_io(kq->rptr_kernel, 0, sizeof(*kq->rptr_kernel));
+	memset_io(kq->wptr_kernel, 0, dev->kfd->device_info.doorbell_size);
 
 	prop.queue_size = queue_size;
 	prop.is_interop = false;
@@ -231,8 +231,8 @@ int kq_acquire_packet_buffer(struct kernel_queue *kq,
 {
 	size_t available_size;
 	size_t queue_size_dwords;
-	uint32_t wptr, rptr;
-	uint64_t wptr64;
+	volatile uint32_t wptr, rptr;
+	volatile uint64_t wptr64;
 	unsigned int *queue_address;
 
 	/* When rptr == wptr, the buffer is empty.

--- a/drivers/gpu/drm/amd/amdkfd/kfd_mqd_manager_v10.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_mqd_manager_v10.c
@@ -32,20 +32,20 @@
 #include "gc/gc_10_1_0_sh_mask.h"
 #include "amdgpu_amdkfd.h"
 
-static inline struct v10_compute_mqd *get_mqd(void *mqd)
+static inline volatile struct v10_compute_mqd *get_mqd(void *mqd)
 {
-	return (struct v10_compute_mqd *)mqd;
+	return (volatile struct v10_compute_mqd *)mqd;
 }
 
-static inline struct v10_sdma_mqd *get_sdma_mqd(void *mqd)
+static inline volatile struct v10_sdma_mqd *get_sdma_mqd(void *mqd)
 {
-	return (struct v10_sdma_mqd *)mqd;
+	return (volatile struct v10_sdma_mqd *)mqd;
 }
 
 static void update_cu_mask(struct mqd_manager *mm, void *mqd,
 			struct mqd_update_info *minfo)
 {
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 	uint32_t se_mask[4] = {0}; /* 4 is the max # of SEs */
 
 	if (!minfo || !minfo->cu_mask.ptr)
@@ -67,7 +67,7 @@ static void update_cu_mask(struct mqd_manager *mm, void *mqd,
 		m->compute_static_thread_mgmt_se3);
 }
 
-static void set_priority(struct v10_compute_mqd *m, struct queue_properties *q)
+static void set_priority(volatile struct v10_compute_mqd *m, struct queue_properties *q)
 {
 	m->cp_hqd_pipe_priority = pipe_priority_map[q->priority];
 	m->cp_hqd_queue_priority = q->priority;
@@ -90,12 +90,12 @@ static void init_mqd(struct mqd_manager *mm, void **mqd,
 			struct queue_properties *q)
 {
 	uint64_t addr;
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 
 	m = (struct v10_compute_mqd *) mqd_mem_obj->cpu_ptr;
 	addr = mqd_mem_obj->gpu_addr;
 
-	memset(m, 0, sizeof(struct v10_compute_mqd));
+	memset_io(m, 0, sizeof(struct v10_compute_mqd));
 
 	m->header = 0xC0310800;
 	m->compute_pipelinestat_enable = 1;
@@ -163,7 +163,7 @@ static void update_mqd(struct mqd_manager *mm, void *mqd,
 			struct queue_properties *q,
 			struct mqd_update_info *minfo)
 {
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 
 	m = get_mqd(mqd);
 
@@ -237,7 +237,7 @@ static int get_wave_state(struct mqd_manager *mm, void *mqd,
 			  u32 *ctl_stack_used_size,
 			  u32 *save_area_used_size)
 {
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 	struct kfd_context_save_area_header header;
 
 	m = get_mqd(mqd);
@@ -271,11 +271,11 @@ static int get_wave_state(struct mqd_manager *mm, void *mqd,
 
 static void checkpoint_mqd(struct mqd_manager *mm, void *mqd, void *mqd_dst, void *ctl_stack_dst)
 {
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 
 	m = get_mqd(mqd);
 
-	memcpy(mqd_dst, m, sizeof(struct v10_compute_mqd));
+	memcpy_fromio(mqd_dst, m, sizeof(struct v10_compute_mqd));
 }
 
 static void restore_mqd(struct mqd_manager *mm, void **mqd,
@@ -285,12 +285,12 @@ static void restore_mqd(struct mqd_manager *mm, void **mqd,
 			const void *ctl_stack_src, const u32 ctl_stack_size)
 {
 	uint64_t addr;
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 
 	m = (struct v10_compute_mqd *) mqd_mem_obj->cpu_ptr;
 	addr = mqd_mem_obj->gpu_addr;
 
-	memcpy(m, mqd_src, sizeof(*m));
+	memcpy_toio(m, mqd_src, sizeof(*m));
 
 	*mqd = m;
 	if (gart_addr)
@@ -309,7 +309,7 @@ static void init_mqd_hiq(struct mqd_manager *mm, void **mqd,
 			struct kfd_mem_obj *mqd_mem_obj, uint64_t *gart_addr,
 			struct queue_properties *q)
 {
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 
 	init_mqd(mm, mqd, mqd_mem_obj, gart_addr, q);
 
@@ -324,7 +324,7 @@ static int destroy_hiq_mqd(struct mqd_manager *mm, void *mqd,
 			uint32_t pipe_id, uint32_t queue_id)
 {
 	int err;
-	struct v10_compute_mqd *m;
+	volatile struct v10_compute_mqd *m;
 	u32 doorbell_off;
 
 	m = get_mqd(mqd);
@@ -343,11 +343,11 @@ static void init_mqd_sdma(struct mqd_manager *mm, void **mqd,
 		struct kfd_mem_obj *mqd_mem_obj, uint64_t *gart_addr,
 		struct queue_properties *q)
 {
-	struct v10_sdma_mqd *m;
+	volatile struct v10_sdma_mqd *m;
 
 	m = (struct v10_sdma_mqd *) mqd_mem_obj->cpu_ptr;
 
-	memset(m, 0, sizeof(struct v10_sdma_mqd));
+	memset_io(m, 0, sizeof(struct v10_sdma_mqd));
 
 	*mqd = m;
 	if (gart_addr)
@@ -362,7 +362,7 @@ static void update_mqd_sdma(struct mqd_manager *mm, void *mqd,
 			struct queue_properties *q,
 			struct mqd_update_info *minfo)
 {
-	struct v10_sdma_mqd *m;
+	volatile struct v10_sdma_mqd *m;
 
 	m = get_sdma_mqd(mqd);
 	m->sdmax_rlcx_rb_cntl = (ffs(q->queue_size / sizeof(unsigned int)) - 1)
@@ -390,11 +390,11 @@ static void checkpoint_mqd_sdma(struct mqd_manager *mm,
 				void *mqd_dst,
 				void *ctl_stack_dst)
 {
-	struct v10_sdma_mqd *m;
+	volatile struct v10_sdma_mqd *m;
 
 	m = get_sdma_mqd(mqd);
 
-	memcpy(mqd_dst, m, sizeof(struct v10_sdma_mqd));
+	memcpy_fromio(mqd_dst, m, sizeof(struct v10_sdma_mqd));
 }
 
 static void restore_mqd_sdma(struct mqd_manager *mm, void **mqd,
@@ -405,12 +405,12 @@ static void restore_mqd_sdma(struct mqd_manager *mm, void **mqd,
 			     const u32 ctl_stack_size)
 {
 	uint64_t addr;
-	struct v10_sdma_mqd *m;
+	volatile struct v10_sdma_mqd *m;
 
 	m = (struct v10_sdma_mqd *) mqd_mem_obj->cpu_ptr;
 	addr = mqd_mem_obj->gpu_addr;
 
-	memcpy(m, mqd_src, sizeof(*m));
+	memcpy_toio(m, mqd_src, sizeof(*m));
 
 	m->sdmax_rlcx_doorbell_offset =
 		qp->doorbell_off << SDMA0_RLC0_DOORBELL_OFFSET__OFFSET__SHIFT;

--- a/drivers/gpu/drm/amd/amdkfd/kfd_mqd_manager_v11.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_mqd_manager_v11.c
@@ -44,7 +44,7 @@ static inline struct v11_sdma_mqd *get_sdma_mqd(void *mqd)
 static void update_cu_mask(struct mqd_manager *mm, void *mqd,
 			   struct mqd_update_info *minfo)
 {
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 	uint32_t se_mask[KFD_MAX_NUM_SE] = {0};
 	bool has_wa_flag = minfo && (minfo->update_flag & (UPDATE_FLAG_DBG_WA_ENABLE |
 			UPDATE_FLAG_DBG_WA_DISABLE));
@@ -93,7 +93,7 @@ static void update_cu_mask(struct mqd_manager *mm, void *mqd,
 		m->compute_static_thread_mgmt_se7);
 }
 
-static void set_priority(struct v11_compute_mqd *m, struct queue_properties *q)
+static void set_priority(volatile struct v11_compute_mqd *m, struct queue_properties *q)
 {
 	m->cp_hqd_pipe_priority = pipe_priority_map[q->priority];
 	m->cp_hqd_queue_priority = q->priority;
@@ -125,7 +125,7 @@ static void init_mqd(struct mqd_manager *mm, void **mqd,
 			struct queue_properties *q)
 {
 	uint64_t addr;
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 	int size;
 	uint32_t wa_mask = q->is_dbg_wa ? 0xffff : 0xffffffff;
 
@@ -137,7 +137,7 @@ static void init_mqd(struct mqd_manager *mm, void **mqd,
 	else
 		size = sizeof(struct v11_compute_mqd);
 
-	memset(m, 0, size);
+	memset_io(m, 0, size);
 
 	m->header = 0xC0310800;
 	m->compute_pipelinestat_enable = 1;
@@ -217,7 +217,7 @@ static void update_mqd(struct mqd_manager *mm, void *mqd,
 		       struct queue_properties *q,
 		       struct mqd_update_info *minfo)
 {
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 
 	m = get_mqd(mqd);
 
@@ -280,7 +280,7 @@ static void update_mqd(struct mqd_manager *mm, void *mqd,
 
 static uint32_t read_doorbell_id(void *mqd)
 {
-	struct v11_compute_mqd *m = (struct v11_compute_mqd *)mqd;
+	volatile struct v11_compute_mqd *m = (struct v11_compute_mqd *)mqd;
 
 	return m->queue_doorbell_id0;
 }
@@ -291,7 +291,7 @@ static int get_wave_state(struct mqd_manager *mm, void *mqd,
 			  u32 *ctl_stack_used_size,
 			  u32 *save_area_used_size)
 {
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 	struct kfd_context_save_area_header header;
 
 	m = get_mqd(mqd);
@@ -324,11 +324,11 @@ static int get_wave_state(struct mqd_manager *mm, void *mqd,
 
 static void checkpoint_mqd(struct mqd_manager *mm, void *mqd, void *mqd_dst, void *ctl_stack_dst)
 {
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 
 	m = get_mqd(mqd);
 
-	memcpy(mqd_dst, m, sizeof(struct v11_compute_mqd));
+	memcpy_fromio(mqd_dst, m, sizeof(struct v11_compute_mqd));
 }
 
 static void restore_mqd(struct mqd_manager *mm, void **mqd,
@@ -338,14 +338,14 @@ static void restore_mqd(struct mqd_manager *mm, void **mqd,
 			const void *ctl_stack_src, const u32 ctl_stack_size)
 {
 	uint64_t addr;
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 
 	m = (struct v11_compute_mqd *) mqd_mem_obj->cpu_ptr;
 	addr = mqd_mem_obj->gpu_addr;
 
-	memcpy(m, mqd_src, sizeof(*m));
+	memcpy_toio(m, mqd_src, sizeof(*m));
 
-	*mqd = m;
+	*mqd = (void*)m;
 	if (gart_addr)
 		*gart_addr = addr;
 
@@ -363,7 +363,7 @@ static void init_mqd_hiq(struct mqd_manager *mm, void **mqd,
 			struct kfd_mem_obj *mqd_mem_obj, uint64_t *gart_addr,
 			struct queue_properties *q)
 {
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 
 	init_mqd(mm, mqd, mqd_mem_obj, gart_addr, q);
 
@@ -378,7 +378,7 @@ static int destroy_hiq_mqd(struct mqd_manager *mm, void *mqd,
 			uint32_t pipe_id, uint32_t queue_id)
 {
 	int err;
-	struct v11_compute_mqd *m;
+	volatile struct v11_compute_mqd *m;
 	u32 doorbell_off;
 
 	m = get_mqd(mqd);
@@ -407,7 +407,7 @@ static void init_mqd_sdma(struct mqd_manager *mm, void **mqd,
 	else
 		size = sizeof(struct v11_sdma_mqd);
 
-	memset(m, 0, size);
+	memset_io(m, 0, size);
 	*mqd = m;
 	if (gart_addr)
 		*gart_addr = mqd_mem_obj->gpu_addr;

--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn30/dcn30_clk_mgr.c
+++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn30/dcn30_clk_mgr.c
@@ -333,7 +333,7 @@ static void dcn3_notify_wm_ranges(struct clk_mgr *clk_mgr_base)
 		// should log failure
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	/* collect valid ranges, place in pmfw table */
 	for (i = 0; i < WM_SET_COUNT; i++)

--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn301/vg_clk_mgr.c
+++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn301/vg_clk_mgr.c
@@ -451,7 +451,7 @@ static void vg_notify_wm_ranges(struct clk_mgr *clk_mgr_base)
 	if (!table || clk_mgr_vgh->smu_wm_set.mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	vg_build_watermark_ranges(clk_mgr_base->bw_params, table);
 
@@ -646,7 +646,7 @@ static void vg_get_dpm_table_from_smu(struct clk_mgr_internal *clk_mgr,
 	if (!table || smu_dpm_clks->mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn301_smu_set_dram_addr_high(clk_mgr,
 			smu_dpm_clks->mc_address.high_part);

--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn31/dcn31_clk_mgr.c
+++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn31/dcn31_clk_mgr.c
@@ -485,7 +485,7 @@ static void dcn31_notify_wm_ranges(struct clk_mgr *clk_mgr_base)
 	if (!table || clk_mgr_dcn31->smu_wm_set.mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn31_build_watermark_ranges(clk_mgr_base->bw_params, table);
 
@@ -507,7 +507,7 @@ static void dcn31_get_dpm_table_from_smu(struct clk_mgr_internal *clk_mgr,
 	if (!table || smu_dpm_clks->mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn31_smu_set_dram_addr_high(clk_mgr,
 			smu_dpm_clks->mc_address.high_part);

--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn314/dcn314_clk_mgr.c
+++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn314/dcn314_clk_mgr.c
@@ -500,7 +500,7 @@ static void dcn314_notify_wm_ranges(struct clk_mgr *clk_mgr_base)
 	if (!table || clk_mgr_dcn314->smu_wm_set.mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn314_build_watermark_ranges(clk_mgr_base->bw_params, table);
 
@@ -522,7 +522,7 @@ static void dcn314_get_dpm_table_from_smu(struct clk_mgr_internal *clk_mgr,
 	if (!table || smu_dpm_clks->mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn314_smu_set_dram_addr_high(clk_mgr,
 			smu_dpm_clks->mc_address.high_part);

--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn315/dcn315_clk_mgr.c
+++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn315/dcn315_clk_mgr.c
@@ -445,7 +445,7 @@ static void dcn315_notify_wm_ranges(struct clk_mgr *clk_mgr_base)
 	if (!table || clk_mgr_dcn315->smu_wm_set.mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn315_build_watermark_ranges(clk_mgr_base->bw_params, table);
 
@@ -467,7 +467,7 @@ static void dcn315_get_dpm_table_from_smu(struct clk_mgr_internal *clk_mgr,
 	if (!table || smu_dpm_clks->mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn315_smu_set_dram_addr_high(clk_mgr,
 			smu_dpm_clks->mc_address.high_part);

--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn316/dcn316_clk_mgr.c
+++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn316/dcn316_clk_mgr.c
@@ -407,7 +407,7 @@ static void dcn316_notify_wm_ranges(struct clk_mgr *clk_mgr_base)
 	if (!table || clk_mgr_dcn316->smu_wm_set.mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn316_build_watermark_ranges(clk_mgr_base->bw_params, table);
 
@@ -429,7 +429,7 @@ static void dcn316_get_dpm_table_from_smu(struct clk_mgr_internal *clk_mgr,
 	if (!table || smu_dpm_clks->mc_address.quad_part == 0)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	dcn316_smu_set_dram_addr_high(clk_mgr,
 			smu_dpm_clks->mc_address.high_part);

--- a/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn32/dcn32_clk_mgr.c
+++ b/drivers/gpu/drm/amd/display/dc/clk_mgr/dcn32/dcn32_clk_mgr.c
@@ -789,7 +789,7 @@ static void dcn32_notify_wm_ranges(struct clk_mgr *clk_mgr_base)
 	if (!table)
 		return;
 
-	memset(table, 0, sizeof(*table));
+	memset_io(table, 0, sizeof(*table));
 
 	/* collect valid ranges, place in pmfw table */
 	for (i = 0; i < WM_SET_COUNT; i++)

--- a/include/drm/drm_cache.h
+++ b/include/drm/drm_cache.h
@@ -45,6 +45,9 @@ bool drm_need_swiotlb(int dma_bits);
 
 static inline bool drm_arch_can_wc_memory(void)
 {
+#if defined(CONFIG_DRM_ARCH_CAN_WC)
+	return true;
+#endif
 #if defined(CONFIG_PPC) && !defined(CONFIG_NOT_COHERENT_CACHE)
 	return false;
 #elif defined(CONFIG_MIPS) && defined(CONFIG_CPU_LOONGSON64)


### PR DESCRIPTION
Coreforge's gpu branch applied to the latest [raspberrypi/linux:rpi-6.6.y](https://github.com/raspberrypi/linux/pull/raspberrypi/linux:rpi-6.6.y) branch, resolved conflicts, applied fixes per checkpatch review, and made additional changes (may revert).

Source: https://github.com/Coreforge/linux/tree/rpi-6.6.y-gpu